### PR TITLE
Revert "Fixed Package"

### DIFF
--- a/operation_test.go
+++ b/operation_test.go
@@ -1,4 +1,4 @@
-package scope
+package scopes
 
 import (
 	"testing"


### PR DESCRIPTION
This reverts commit 7f82c7b8cc0ff94907ac0c20a572bfdb5459614a.

Whatever fix this was envisioning, it had the opposite effect, as
this has introduced 2 packages in the same directory and blown up
the build.